### PR TITLE
Add connection string to access Azure SQL Db

### DIFF
--- a/appsettings.json
+++ b/appsettings.json
@@ -5,5 +5,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=tcp:altrucodedb.database.windows.net,1433;Initial Catalog=AltruCodeDB;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;Authentication=\"Active Directory Default\";"
+  },
   "AllowedHosts": "*"
 }


### PR DESCRIPTION
## Add connection string to access Azure SQL Db
Add connection string field to appsettings file to provide keys to access Azure SQL Db